### PR TITLE
Removed blank space being spammed in console upon chat clearing

### DIFF
--- a/src/me/athena222/clearchat/Main.java
+++ b/src/me/athena222/clearchat/Main.java
@@ -23,7 +23,11 @@ public class Main extends JavaPlugin {
 		String b = "";
 
 		if (!(sender instanceof Player)) {
-			for (int i = 0; i < 250; i++) getServer().broadcastMessage(b);
+			for (int i = 0; i < 250; i++) {
+				for (Player online : Bukkit.getOnlinePlayers()) {
+					online.sendMessage(b);
+				}
+			} 
 			getServer().broadcastMessage(clearchatconsole);
 			return true;
 		}
@@ -36,7 +40,11 @@ public class Main extends JavaPlugin {
 
 		if (args.length == 0) {
 			if ((cmd.getName().equalsIgnoreCase("clearchat")) && (player.hasPermission("clearchat.use"))) {
-				for (int i = 0; i < 250; i++) getServer().broadcastMessage(b);
+				for (int i = 0; i < 250; i++) {
+					for (Player online : Bukkit.getOnlinePlayers()) {
+						online.sendMessage(b);
+					}
+				} 
 				getServer().broadcastMessage(clearchat);
 				return true;
 			}


### PR DESCRIPTION
Not only does [broadcastMessage(String)](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Bukkit.html#broadcastMessage(java.lang.String)) broadcast a message to all players, it also broadcasts a message to the console. Because of this, when you run /clearchat, the console gets spammed with 250 lines of blank space - ouch!

Here's a fix for that.